### PR TITLE
Add Simulation typing and strict props

### DIFF
--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -7,6 +7,8 @@ import EditableFinancialData from './EditableFinancialData';
 import DashboardGrid from './DashboardGrid';
 import SpentTracker from './SpentTracker';
 import { BaseData } from './DashboardData';
+import { DebtItem } from '@/types/debt';
+import { GoalItem } from '@/types/goals';
 import ImportExportControls from './ImportExportControls';
 import { useDashboard } from '@/contexts/DashboardContext';
 
@@ -23,8 +25,8 @@ interface DashboardLayoutProps {
       budget: number;
       color: string;
     }>;
-    debts: Array<any>;
-    goalItems: Array<any>;
+    debts: DebtItem[];
+    goalItems: GoalItem[];
   };
   totalBudget: number;
   totalSpent: number;

--- a/src/components/SimulationControls.tsx
+++ b/src/components/SimulationControls.tsx
@@ -1,6 +1,9 @@
 
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { BaseData } from '@/types/dashboard';
+import { Simulation } from '@/types/simulation';
+import { Category } from '@/types/categories';
 
 interface SimulationChange {
   category: string;
@@ -9,8 +12,8 @@ interface SimulationChange {
 }
 
 interface SimulationControlsProps {
-  baseData: any;
-  simulation: any;
+  baseData: BaseData;
+  simulation: Simulation;
   onUpdate: (changes: SimulationChange[]) => void;
 }
 
@@ -33,7 +36,7 @@ const SimulationControls = ({ baseData, simulation, onUpdate }: SimulationContro
 
   const removeChange = (index: number) => {
     const existingChanges = simulation.changes || [];
-    const updatedChanges = existingChanges.filter((_: any, i: number) => i !== index);
+    const updatedChanges = existingChanges.filter((_, i) => i !== index);
     onUpdate(updatedChanges);
   };
 
@@ -51,7 +54,7 @@ const SimulationControls = ({ baseData, simulation, onUpdate }: SimulationContro
               onChange={(e) => setSelectedCategory(e.target.value)}
               className="w-full bg-slate-700 border border-slate-600 rounded px-3 py-2 text-sm text-green-400"
             >
-              {baseData.categories.map((cat: any) => (
+              {baseData.categories.map((cat: Category) => (
                 <option key={cat.name} value={cat.name}>{cat.name}</option>
               ))}
             </select>

--- a/src/components/SimulationResults.tsx
+++ b/src/components/SimulationResults.tsx
@@ -1,17 +1,21 @@
 
+import { BaseData } from '@/types/dashboard';
+import { Simulation, SimulationChange } from '@/types/simulation';
+import { Category } from '@/types/categories';
+
 interface SimulationResultsProps {
-  baseData: any;
-  simulation: any;
+  baseData: BaseData;
+  simulation: Simulation;
 }
 
 const SimulationResults = ({ baseData, simulation }: SimulationResultsProps) => {
   // Calculate the modified budget based on changes
   const calculateModifiedData = () => {
-    const modifiedCategories = baseData.categories.map((cat: any) => {
-      const categoryChanges = (simulation.changes || []).filter((change: any) => change.category === cat.name);
+    const modifiedCategories = baseData.categories.map((cat: Category) => {
+      const categoryChanges = (simulation.changes || []).filter((change: SimulationChange) => change.category === cat.name);
       let newAmount = cat.amount;
-      
-      categoryChanges.forEach((change: any) => {
+
+      categoryChanges.forEach((change: SimulationChange) => {
         if (change.type === 'increase') {
           newAmount += change.change;
         } else {
@@ -22,8 +26,8 @@ const SimulationResults = ({ baseData, simulation }: SimulationResultsProps) => 
       return { ...cat, amount: Math.max(0, newAmount) };
     });
 
-    const originalTotal = baseData.categories.reduce((sum: number, cat: any) => sum + cat.amount, 0);
-    const newTotal = modifiedCategories.reduce((sum: number, cat: any) => sum + cat.amount, 0);
+    const originalTotal = baseData.categories.reduce((sum: number, cat: Category) => sum + cat.amount, 0);
+    const newTotal = modifiedCategories.reduce((sum: number, cat: Category) => sum + cat.amount, 0);
     const savings = originalTotal - newTotal;
     const newRemaining = baseData.income - newTotal;
 
@@ -36,7 +40,7 @@ const SimulationResults = ({ baseData, simulation }: SimulationResultsProps) => 
   };
 
   const modifiedData = calculateModifiedData();
-  const originalTotal = baseData.categories.reduce((sum: number, cat: any) => sum + cat.amount, 0);
+  const originalTotal = baseData.categories.reduce((sum: number, cat: Category) => sum + cat.amount, 0);
   const originalRemaining = baseData.income - originalTotal;
 
   return (
@@ -66,7 +70,7 @@ const SimulationResults = ({ baseData, simulation }: SimulationResultsProps) => 
       <div className="bg-black/30 p-4 rounded border border-slate-600">
         <h3 className="text-sm font-bold text-amber-400 mb-3">CATEGORY CHANGES</h3>
         <div className="space-y-2">
-          {modifiedData.categories.map((cat: any, index: number) => {
+          {modifiedData.categories.map((cat: Category, index: number) => {
             const originalCat = baseData.categories[index];
             const hasChanged = cat.amount !== originalCat.amount;
             const change = cat.amount - originalCat.amount;

--- a/src/types/simulation.ts
+++ b/src/types/simulation.ts
@@ -1,0 +1,15 @@
+/**
+ * Simulation-related type definitions
+ */
+export interface SimulationChange {
+  category: string;
+  change: number;
+  type: 'increase' | 'decrease';
+}
+
+export interface Simulation {
+  id: number;
+  name: string;
+  changes: SimulationChange[];
+  isActive: boolean;
+}


### PR DESCRIPTION
## Summary
- define `Simulation` interface for budget sim scenarios
- type SimulationControls and SimulationResults props
- type monthlyData debts/goals in DashboardLayout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build:dev` *(fails: vite not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864d7614330832ba6774f94fcd0f49f