### PR TITLE
Share BaseData defaults between dashboard and simulator

### DIFF
--- a/src/components/BudgetSimulator.tsx
+++ b/src/components/BudgetSimulator.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import SimulationControls from './SimulationControls';
 import SimulationResults from './SimulationResults';
 import { BaseData } from './DashboardData';
+import { defaultBaseData } from '@/data/defaultBaseData';
 
 interface BudgetSimulatorProps {
   baseData?: BaseData;
@@ -12,17 +13,7 @@ interface BudgetSimulatorProps {
 
 const BudgetSimulator = ({ baseData: propBaseData }: BudgetSimulatorProps) => {
   // Use prop data if available, otherwise fall back to default data
-  const [baseData] = useState(propBaseData || {
-    income: 5000,
-    categories: [
-      { name: 'NEEDS', amount: 2000, budget: 2500, color: 'bg-red-500' },
-      { name: 'WANTS', amount: 800, budget: 1000, color: 'bg-orange-500' },
-      { name: 'DEBT', amount: 300, budget: 400, color: 'bg-yellow-500' },
-      { name: 'GOALS', amount: 1200, budget: 1800, color: 'bg-green-500' }
-    ],
-    debts: [],
-    goals: []
-  });
+  const [baseData] = useState(propBaseData || defaultBaseData);
 
   const [simulations, setSimulations] = useState([
     {

--- a/src/components/DashboardData.tsx
+++ b/src/components/DashboardData.tsx
@@ -5,90 +5,12 @@ import { Category } from '@/types/categories';
 import { BaseData } from '@/types/dashboard';
 import { usePersistedState } from '@/hooks/usePersistedState';
 import { toast } from '@/components/ui/sonner';
+import { defaultBaseData } from '@/data/defaultBaseData';
 
 export type { Category, GoalItem, BaseData };
 
 export const useDashboardData = () => {
-  const defaultData: BaseData = {
-    income: 5000,
-    categories: [{
-      name: 'NEEDS' as const,
-      amount: 0,
-      budget: 2500,
-      color: 'bg-red-500'
-    }, {
-      name: 'WANTS' as const,
-      amount: 0,
-      budget: 1000,
-      color: 'bg-orange-500'
-    }, {
-      name: 'DEBT' as const,
-      amount: 0,
-      budget: 400,
-      color: 'bg-yellow-500'
-    }, {
-      name: 'GOALS' as const,
-      amount: 0,
-      budget: 1800,
-      color: 'bg-green-500'
-    }],
-    debts: [{
-      name: 'Credit Card - Chase',
-      balance: 3500,
-      minPayment: 105,
-      plannedPayment: 200,
-      totalPaid: 150,
-      interestRate: 24.99,
-      type: 'credit_card' as const
-    }, {
-      name: 'Student Loan',
-      balance: 15000,
-      minPayment: 180,
-      plannedPayment: 250,
-      totalPaid: 180,
-      interestRate: 6.5,
-      type: 'loan' as const
-    }, {
-      name: 'Car Loan',
-      balance: 12000,
-      minPayment: 285,
-      plannedPayment: 350,
-      totalPaid: 285,
-      interestRate: 4.2,
-      type: 'loan' as const
-    }],
-    goals: [{
-      name: 'Emergency Fund',
-      target: 15000,
-      current: 8500,
-      monthlyContribution: 500,
-      plannedContribution: 750,
-      type: 'emergency_fund' as const,
-      deadline: 'Dec 2025'
-    }, {
-      name: 'Retirement 401k',
-      target: 100000,
-      current: 35000,
-      monthlyContribution: 800,
-      plannedContribution: 1000,
-      type: 'retirement' as const
-    }, {
-      name: 'Vacation Fund',
-      target: 5000,
-      current: 1200,
-      monthlyContribution: 200,
-      plannedContribution: 300,
-      type: 'vacation' as const,
-      deadline: 'Jun 2025'
-    }, {
-      name: 'Stock Portfolio',
-      target: 25000,
-      current: 12500,
-      monthlyContribution: 400,
-      plannedContribution: 600,
-      type: 'investment' as const
-    }]
-  };
+  const defaultData = defaultBaseData;
 
   // Migration function for handling data structure changes
   const migrateData = (oldData: any, oldVersion: number): BaseData => {

--- a/src/data/defaultBaseData.ts
+++ b/src/data/defaultBaseData.ts
@@ -1,0 +1,96 @@
+import { BaseData } from '@/types/dashboard';
+
+export const defaultBaseData: BaseData = {
+  income: 5000,
+  categories: [
+    {
+      name: 'NEEDS' as const,
+      amount: 0,
+      budget: 2500,
+      color: 'bg-red-500'
+    },
+    {
+      name: 'WANTS' as const,
+      amount: 0,
+      budget: 1000,
+      color: 'bg-orange-500'
+    },
+    {
+      name: 'DEBT' as const,
+      amount: 0,
+      budget: 400,
+      color: 'bg-yellow-500'
+    },
+    {
+      name: 'GOALS' as const,
+      amount: 0,
+      budget: 1800,
+      color: 'bg-green-500'
+    }
+  ],
+  debts: [
+    {
+      name: 'Credit Card - Chase',
+      balance: 3500,
+      minPayment: 105,
+      plannedPayment: 200,
+      totalPaid: 150,
+      interestRate: 24.99,
+      type: 'credit_card' as const
+    },
+    {
+      name: 'Student Loan',
+      balance: 15000,
+      minPayment: 180,
+      plannedPayment: 250,
+      totalPaid: 180,
+      interestRate: 6.5,
+      type: 'loan' as const
+    },
+    {
+      name: 'Car Loan',
+      balance: 12000,
+      minPayment: 285,
+      plannedPayment: 350,
+      totalPaid: 285,
+      interestRate: 4.2,
+      type: 'loan' as const
+    }
+  ],
+  goals: [
+    {
+      name: 'Emergency Fund',
+      target: 15000,
+      current: 8500,
+      monthlyContribution: 500,
+      plannedContribution: 750,
+      type: 'emergency_fund' as const,
+      deadline: 'Dec 2025'
+    },
+    {
+      name: 'Retirement 401k',
+      target: 100000,
+      current: 35000,
+      monthlyContribution: 800,
+      plannedContribution: 1000,
+      type: 'retirement' as const
+    },
+    {
+      name: 'Vacation Fund',
+      target: 5000,
+      current: 1200,
+      monthlyContribution: 200,
+      plannedContribution: 300,
+      type: 'vacation' as const,
+      deadline: 'Jun 2025'
+    },
+    {
+      name: 'Stock Portfolio',
+      target: 25000,
+      current: 12500,
+      monthlyContribution: 400,
+      plannedContribution: 600,
+      type: 'investment' as const
+    }
+  ]
+};


### PR DESCRIPTION
## Summary
- extract `BaseData` default object to `src/data/defaultBaseData.ts`
- import and use this shared default in `DashboardData` and `BudgetSimulator`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864d7657ea4832ba1b8014ee71fdfb8