### PR TITLE
Fix remaining calculation in dashboard grid

### DIFF
--- a/src/components/DashboardGrid.tsx
+++ b/src/components/DashboardGrid.tsx
@@ -23,6 +23,7 @@ interface DashboardGridProps {
   spendingCategories: Category[];
   debts: DebtItem[];
   goals: GoalItem[];
+  totalBudget: number;
   totalMinPayments: number;
   totalPlannedPayments: number;
   totalPaid: number;
@@ -33,6 +34,7 @@ const DashboardGrid = ({
   spendingCategories,
   debts,
   goals,
+  totalBudget,
   totalMinPayments,
   totalPlannedPayments,
   totalPaid,
@@ -41,7 +43,8 @@ const DashboardGrid = ({
   // Calculate savings progress (simplified)
   const savingsCurrent = goals.reduce((sum, goal) => sum + goal.current, 0);
   const savingsTarget = goals.reduce((sum, goal) => sum + goal.target, 0);
-  const remaining = spendingCategories.reduce((sum, cat) => sum - cat.amount, 0);
+  const totalSpent = spendingCategories.reduce((sum, cat) => sum + cat.amount, 0);
+  const remaining = totalBudget - totalSpent;
 
   return (
     <div className="grid grid-cols-1 gap-6">

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -130,10 +130,11 @@ const DashboardLayout = ({
       />
 
       {/* Main Content Grid - Will update based on spending changes */}
-      <DashboardGrid 
+      <DashboardGrid
         spendingCategories={spendingCategories}
         debts={monthlyData.debts}
         goals={monthlyData.goalItems}
+        totalBudget={totalBudget}
         totalMinPayments={totalMinPayments}
         totalPlannedPayments={totalPlannedPayments}
         totalPaid={totalPaid}


### PR DESCRIPTION
## Summary
- compute `totalSpent` using `reduce` and calculate the `remaining` budget correctly
- pass `totalBudget` down to `DashboardGrid`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_6864d7677528832bbf8f31cde9341bff