### PR TITLE
Use navigate(-1) for back buttons

### DIFF
--- a/src/pages/DebtDetails.tsx
+++ b/src/pages/DebtDetails.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
 import DebtBreakdown from '../components/DebtBreakdown';
 import { useDashboard } from '../contexts/DashboardContext';
+import { useNavigate } from 'react-router-dom';
 
 const DebtDetails = () => {
   const {
@@ -17,8 +18,10 @@ const DebtDetails = () => {
     setBaseData
   } = useDashboard();
 
+  const navigate = useNavigate();
+
   const handleBack = () => {
-    window.history.back();
+    navigate(-1);
   };
 
   const handleBudgetUpdate = (newBudgetAmount: number) => {

--- a/src/pages/GoalsDetails.tsx
+++ b/src/pages/GoalsDetails.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
 import GoalsBreakdown from '../components/GoalsBreakdown';
 import { useDashboard } from '../contexts/DashboardContext';
+import { useNavigate } from 'react-router-dom';
 
 const GoalsDetails = () => {
   const {
@@ -12,9 +13,10 @@ const GoalsDetails = () => {
     handleDeleteGoal,
     handleAddGoal
   } = useDashboard();
+  const navigate = useNavigate();
 
   const handleBack = () => {
-    window.history.back();
+    navigate(-1);
   };
 
   // Get the goals spent amount from the GOALS category

--- a/src/pages/NeedsDetails.tsx
+++ b/src/pages/NeedsDetails.tsx
@@ -4,12 +4,14 @@ import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
 import NeedsBreakdown from '../components/NeedsBreakdown';
 import { useDashboard } from '../contexts/DashboardContext';
+import { useNavigate } from 'react-router-dom';
 
 const NeedsDetails = () => {
   const { baseData } = useDashboard();
+  const navigate = useNavigate();
 
   const handleBack = () => {
-    window.history.back();
+    navigate(-1);
   };
 
   return (

--- a/src/pages/WantsDetails.tsx
+++ b/src/pages/WantsDetails.tsx
@@ -4,12 +4,14 @@ import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
 import WantsBreakdown from '../components/WantsBreakdown';
 import { useDashboard } from '../contexts/DashboardContext';
+import { useNavigate } from 'react-router-dom';
 
 const WantsDetails = () => {
   const { baseData } = useDashboard();
+  const navigate = useNavigate();
 
   const handleBack = () => {
-    window.history.back();
+    navigate(-1);
   };
 
   return (


### PR DESCRIPTION
## Summary
- use `useNavigate` hook instead of `window.history.back()` in detail pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864d76976a8832b8ff50b19dbd42dce