### PR TITLE
Simplify dashboard and add budget manager page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -11,6 +10,7 @@ import NeedsDetails from "./pages/NeedsDetails";
 import WantsDetails from "./pages/WantsDetails";
 import DebtDetails from "./pages/DebtDetails";
 import GoalsDetails from "./pages/GoalsDetails";
+import Manage from "./pages/Manage";
 
 const queryClient = new QueryClient();
 
@@ -28,6 +28,7 @@ const App = () => {
               <Route path="/wants" element={<WantsDetails />} />
               <Route path="/debt" element={<DebtDetails />} />
               <Route path="/goals" element={<GoalsDetails />} />
+              <Route path="/manage" element={<Manage />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/components/BalanceSheetCard.tsx
+++ b/src/components/BalanceSheetCard.tsx
@@ -1,44 +1,28 @@
-import { Card } from '@/components/ui/card';
-import DebtBreakdown from './DebtBreakdown';
-import GoalsBreakdown from './GoalsBreakdown';
-import { useDashboard } from '@/contexts/DashboardContext';
+import { Card } from "@/components/ui/card";
+import { useDashboard } from "@/contexts/DashboardContext";
 
 const BalanceSheetCard = () => {
-  const {
-    baseData,
-    handleDebtUpdate,
-    handleDeleteDebt,
-    handleAddDebt,
-    handleDebtStrategyChange,
-    debtStrategy,
-    handleGoalUpdate,
-    handleDeleteGoal,
-    handleAddGoal,
-    handleSpentUpdate,
-    setBaseData
-  } = useDashboard();
-
-  const debtBudget = baseData.categories.find(cat => cat.name === 'DEBT')?.budget || 0;
-  const debtSpent = baseData.categories.find(cat => cat.name === 'DEBT')?.amount || 0;
-  const goalsSpent = baseData.categories.find(cat => cat.name === 'GOALS')?.amount || 0;
+  const { baseData } = useDashboard();
 
   const assets = baseData.goals.reduce((sum, g) => sum + g.current, 0);
   const liabilities = baseData.debts.reduce((sum, d) => sum + d.balance, 0);
   const netWorth = assets - liabilities;
 
-  const handleBudgetUpdate = (newBudgetAmount: number) => {
-    const updatedCategories = baseData.categories.map(cat =>
-      cat.name === 'DEBT' ? { ...cat, budget: newBudgetAmount } : cat
-    );
-    setBaseData({ ...baseData, categories: updatedCategories });
-  };
+  const totalGoalsTarget = baseData.goals.reduce((sum, g) => sum + g.target, 0);
+  const totalGoalsCurrent = baseData.goals.reduce(
+    (sum, g) => sum + g.current,
+    0,
+  );
+  const goalsPercentage =
+    totalGoalsTarget > 0 ? (totalGoalsCurrent / totalGoalsTarget) * 100 : 0;
 
-  const handleSpentUpdateLocal = (newSpentAmount: number) => {
-    const updatedCategories = baseData.categories.map(cat =>
-      cat.name === 'DEBT' ? { ...cat, amount: newSpentAmount } : cat
-    );
-    handleSpentUpdate({ categories: updatedCategories });
-  };
+  const debtBudget =
+    baseData.categories.find((cat) => cat.name === "DEBT")?.budget || 0;
+  const debtPaid = baseData.debts.reduce(
+    (sum, d) => sum + (d.totalPaid || 0),
+    0,
+  );
+  const debtPercentage = debtBudget > 0 ? (debtPaid / debtBudget) * 100 : 0;
 
   return (
     <Card className="bg-slate-800/50 border-slate-700 backdrop-blur-sm">
@@ -50,38 +34,52 @@ const BalanceSheetCard = () => {
         <div className="grid grid-cols-3 gap-4 text-sm">
           <div className="bg-black/30 p-3 rounded border border-slate-600">
             <div className="text-xs text-slate-400 mb-1">ASSETS</div>
-            <div className="text-lg font-bold text-green-400">${assets.toLocaleString()}</div>
+            <div className="text-lg font-bold text-green-400">
+              ${assets.toLocaleString()}
+            </div>
           </div>
           <div className="bg-black/30 p-3 rounded border border-slate-600">
             <div className="text-xs text-slate-400 mb-1">LIABILITIES</div>
-            <div className="text-lg font-bold text-red-400">${liabilities.toLocaleString()}</div>
+            <div className="text-lg font-bold text-red-400">
+              ${liabilities.toLocaleString()}
+            </div>
           </div>
           <div className="bg-black/30 p-3 rounded border border-slate-600">
             <div className="text-xs text-slate-400 mb-1">NET WORTH</div>
-            <div className={`text-lg font-bold ${netWorth >= 0 ? 'text-green-400' : 'text-red-400'}`}>${netWorth.toLocaleString()}</div>
+            <div
+              className={`text-lg font-bold ${netWorth >= 0 ? "text-green-400" : "text-red-400"}`}
+            >
+              ${netWorth.toLocaleString()}
+            </div>
           </div>
         </div>
 
-        <DebtBreakdown
-          debts={baseData.debts}
-          onUpdateDebt={handleDebtUpdate}
-          onDeleteDebt={handleDeleteDebt}
-          onAddDebt={handleAddDebt}
-          onBudgetUpdate={handleBudgetUpdate}
-          onSpentUpdate={handleSpentUpdateLocal}
-          debtBudget={debtBudget}
-          debtSpent={debtSpent}
-          strategy={debtStrategy}
-          onStrategyChange={handleDebtStrategyChange}
-        />
-
-        <GoalsBreakdown
-          goals={baseData.goals}
-          onUpdateGoal={handleGoalUpdate}
-          onDeleteGoal={handleDeleteGoal}
-          onAddGoal={handleAddGoal}
-          goalsSpent={goalsSpent}
-        />
+        <div className="space-y-4">
+          <div>
+            <div className="flex justify-between text-xs text-slate-400 mb-1">
+              <span>Debt Payments</span>
+              <span>{debtPercentage.toFixed(0)}%</span>
+            </div>
+            <div className="w-full bg-slate-700 rounded-full h-3 overflow-hidden">
+              <div
+                className="h-full bg-blue-500"
+                style={{ width: `${Math.min(debtPercentage, 100)}%` }}
+              />
+            </div>
+          </div>
+          <div>
+            <div className="flex justify-between text-xs text-slate-400 mb-1">
+              <span>Savings Progress</span>
+              <span>{goalsPercentage.toFixed(0)}%</span>
+            </div>
+            <div className="w-full bg-slate-700 rounded-full h-3 overflow-hidden">
+              <div
+                className="h-full bg-green-500"
+                style={{ width: `${Math.min(goalsPercentage, 100)}%` }}
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </Card>
   );

--- a/src/components/BudgetManager.tsx
+++ b/src/components/BudgetManager.tsx
@@ -1,0 +1,75 @@
+import { Card } from "@/components/ui/card";
+import EditableFinancialData from "./EditableFinancialData";
+import SpentTracker from "./SpentTracker";
+import CategoryBreakdown from "./CategoryBreakdown";
+import { useDashboard } from "@/contexts/DashboardContext";
+import { useNavigate } from "react-router-dom";
+
+const BudgetManager = () => {
+  const { baseData, handleDataUpdate, handleSpentUpdate } = useDashboard();
+  const navigate = useNavigate();
+
+  const handleNeedsClick = () => navigate("/needs");
+  const handleWantsClick = () => navigate("/wants");
+  const handleDebtClick = () => navigate("/debt");
+  const handleGoalsClick = () => navigate("/goals");
+
+  return (
+    <div className="space-y-6">
+      <Card className="bg-slate-800/50 border-slate-700 backdrop-blur-sm">
+        <div className="p-6">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="w-10 h-10 bg-blue-400/20 rounded-full flex items-center justify-center">
+              <span className="text-lg">📊</span>
+            </div>
+            <h3 className="text-lg font-bold text-blue-400">BUDGET PLANNING</h3>
+          </div>
+          <EditableFinancialData
+            income={baseData.income}
+            categories={baseData.categories}
+            onUpdate={handleDataUpdate}
+          />
+        </div>
+      </Card>
+      <Card className="bg-slate-800/50 border-slate-700 backdrop-blur-sm">
+        <div className="p-6">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="w-10 h-10 bg-purple-400/20 rounded-full flex items-center justify-center">
+              <span className="text-lg">💳</span>
+            </div>
+            <h3 className="text-lg font-bold text-purple-400">
+              SPENDING TRACKER
+            </h3>
+          </div>
+          <SpentTracker
+            categories={baseData.categories}
+            onUpdate={handleSpentUpdate}
+          />
+        </div>
+      </Card>
+      <Card className="bg-slate-800/50 border-slate-700 backdrop-blur-sm">
+        <div className="p-6">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="w-10 h-10 bg-amber-400/20 rounded-full flex items-center justify-center">
+              <span className="text-lg">📈</span>
+            </div>
+            <h3 className="text-lg font-bold text-amber-400">
+              CATEGORY BREAKDOWN
+            </h3>
+          </div>
+          <CategoryBreakdown
+            categories={baseData.categories}
+            debts={baseData.debts}
+            goals={baseData.goals}
+            onDebtClick={handleDebtClick}
+            onGoalsClick={handleGoalsClick}
+            onNeedsClick={handleNeedsClick}
+            onWantsClick={handleWantsClick}
+          />
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default BudgetManager;

--- a/src/components/CashflowCard.tsx
+++ b/src/components/CashflowCard.tsx
@@ -1,30 +1,23 @@
-
-import { Card } from '@/components/ui/card';
-import BudgetOverview from './BudgetOverview';
-import EditableFinancialData from './EditableFinancialData';
-import SpentTracker from './SpentTracker';
-import CategoryBreakdown from './CategoryBreakdown';
-import { useNavigate } from 'react-router-dom';
-import { useDashboard } from '@/contexts/DashboardContext';
-import { useDashboardCalculations } from './DashboardCalculations';
+import { Card } from "@/components/ui/card";
+import CategoryBreakdown from "./CategoryBreakdown";
+import { useNavigate } from "react-router-dom";
+import { useDashboard } from "@/contexts/DashboardContext";
+import { useDashboardCalculations } from "./DashboardCalculations";
 
 const CashflowCard = () => {
-  const { baseData, handleDataUpdate, handleSpentUpdate } = useDashboard();
-  const {
-    spendingCategories,
-    totalBudget,
-    totalSpent,
-    remaining
-  } = useDashboardCalculations(baseData);
+  const { baseData } = useDashboard();
+  const { spendingCategories, totalBudget, totalSpent, remaining } =
+    useDashboardCalculations(baseData);
 
   const navigate = useNavigate();
 
-  const handleNeedsClick = () => navigate('/needs');
-  const handleWantsClick = () => navigate('/wants');
-  const handleDebtClick = () => navigate('/debt');
-  const handleGoalsClick = () => navigate('/goals');
+  const handleNeedsClick = () => navigate("/needs");
+  const handleWantsClick = () => navigate("/wants");
+  const handleDebtClick = () => navigate("/debt");
+  const handleGoalsClick = () => navigate("/goals");
 
-  const spentPercentage = totalBudget > 0 ? (totalSpent / totalBudget) * 100 : 0;
+  const spentPercentage =
+    totalBudget > 0 ? (totalSpent / totalBudget) * 100 : 0;
 
   return (
     <div className="space-y-6">
@@ -36,30 +29,50 @@ const CashflowCard = () => {
               <span className="text-2xl">💰</span>
             </div>
             <div>
-              <h2 className="text-xl font-bold text-amber-400">CASH FLOW DASHBOARD</h2>
-              <p className="text-sm text-slate-400">Monitor your monthly money flow</p>
+              <h2 className="text-xl font-bold text-amber-400">
+                CASH FLOW DASHBOARD
+              </h2>
+              <p className="text-sm text-slate-400">
+                Monitor your monthly money flow
+              </p>
             </div>
           </div>
 
           {/* Quick Stats Grid */}
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
             <div className="bg-black/40 p-4 rounded-lg border border-slate-600">
-              <div className="text-xs text-slate-400 mb-1 uppercase tracking-wide">Monthly Income</div>
-              <div className="text-2xl font-bold text-green-400">${totalBudget.toLocaleString()}</div>
+              <div className="text-xs text-slate-400 mb-1 uppercase tracking-wide">
+                Monthly Income
+              </div>
+              <div className="text-2xl font-bold text-green-400">
+                ${totalBudget.toLocaleString()}
+              </div>
             </div>
             <div className="bg-black/40 p-4 rounded-lg border border-slate-600">
-              <div className="text-xs text-slate-400 mb-1 uppercase tracking-wide">Total Spent</div>
-              <div className="text-2xl font-bold text-red-400">${totalSpent.toLocaleString()}</div>
+              <div className="text-xs text-slate-400 mb-1 uppercase tracking-wide">
+                Total Spent
+              </div>
+              <div className="text-2xl font-bold text-red-400">
+                ${totalSpent.toLocaleString()}
+              </div>
             </div>
             <div className="bg-black/40 p-4 rounded-lg border border-slate-600">
-              <div className="text-xs text-slate-400 mb-1 uppercase tracking-wide">Remaining</div>
-              <div className={`text-2xl font-bold ${remaining >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+              <div className="text-xs text-slate-400 mb-1 uppercase tracking-wide">
+                Remaining
+              </div>
+              <div
+                className={`text-2xl font-bold ${remaining >= 0 ? "text-green-400" : "text-red-400"}`}
+              >
                 ${remaining.toLocaleString()}
               </div>
             </div>
             <div className="bg-black/40 p-4 rounded-lg border border-slate-600">
-              <div className="text-xs text-slate-400 mb-1 uppercase tracking-wide">Usage</div>
-              <div className={`text-2xl font-bold ${spentPercentage <= 100 ? 'text-blue-400' : 'text-red-400'}`}>
+              <div className="text-xs text-slate-400 mb-1 uppercase tracking-wide">
+                Usage
+              </div>
+              <div
+                className={`text-2xl font-bold ${spentPercentage <= 100 ? "text-blue-400" : "text-red-400"}`}
+              >
                 {spentPercentage.toFixed(1)}%
               </div>
             </div>
@@ -72,49 +85,18 @@ const CashflowCard = () => {
               <span>{spentPercentage.toFixed(1)}% used</span>
             </div>
             <div className="w-full bg-slate-700 rounded-full h-3 overflow-hidden">
-              <div 
+              <div
                 className={`h-full transition-all duration-500 ${
-                  spentPercentage >= 100 ? 'bg-red-500' : 
-                  spentPercentage >= 80 ? 'bg-orange-500' : 
-                  'bg-green-500'
+                  spentPercentage >= 100
+                    ? "bg-red-500"
+                    : spentPercentage >= 80
+                      ? "bg-orange-500"
+                      : "bg-green-500"
                 }`}
                 style={{ width: `${Math.min(spentPercentage, 100)}%` }}
               />
             </div>
           </div>
-        </div>
-      </Card>
-
-      {/* Budget Planning Section */}
-      <Card className="bg-slate-800/50 border-slate-700 backdrop-blur-sm">
-        <div className="p-6">
-          <div className="flex items-center gap-3 mb-4">
-            <div className="w-10 h-10 bg-blue-400/20 rounded-full flex items-center justify-center">
-              <span className="text-lg">📊</span>
-            </div>
-            <h3 className="text-lg font-bold text-blue-400">BUDGET PLANNING</h3>
-          </div>
-          <EditableFinancialData
-            income={baseData.income}
-            categories={baseData.categories}
-            onUpdate={handleDataUpdate}
-          />
-        </div>
-      </Card>
-
-      {/* Spending Tracker Section */}
-      <Card className="bg-slate-800/50 border-slate-700 backdrop-blur-sm">
-        <div className="p-6">
-          <div className="flex items-center gap-3 mb-4">
-            <div className="w-10 h-10 bg-purple-400/20 rounded-full flex items-center justify-center">
-              <span className="text-lg">💳</span>
-            </div>
-            <h3 className="text-lg font-bold text-purple-400">SPENDING TRACKER</h3>
-          </div>
-          <SpentTracker
-            categories={baseData.categories}
-            onUpdate={handleSpentUpdate}
-          />
         </div>
       </Card>
 
@@ -125,7 +107,9 @@ const CashflowCard = () => {
             <div className="w-10 h-10 bg-amber-400/20 rounded-full flex items-center justify-center">
               <span className="text-lg">📈</span>
             </div>
-            <h3 className="text-lg font-bold text-amber-400">CATEGORY BREAKDOWN</h3>
+            <h3 className="text-lg font-bold text-amber-400">
+              CATEGORY BREAKDOWN
+            </h3>
           </div>
           <CategoryBreakdown
             categories={spendingCategories}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,12 +1,13 @@
-
-import { useState } from 'react';
-import Dashboard from '../components/Dashboard';
-import BudgetSimulator from '../components/BudgetSimulator';
-import { useDashboard } from '../contexts/DashboardContext';
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Dashboard from "../components/Dashboard";
+import BudgetSimulator from "../components/BudgetSimulator";
+import { useDashboard } from "../contexts/DashboardContext";
 
 const Index = () => {
-  const [activeTab, setActiveTab] = useState('dashboard');
+  const [activeTab, setActiveTab] = useState("dashboard");
   const { baseData } = useDashboard();
+  const navigate = useNavigate();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-green-400 font-mono">
@@ -17,13 +18,25 @@ const Index = () => {
             <div className="flex items-center gap-4">
               <div className="text-3xl">💰</div>
               <div>
-                <h1 className="text-2xl font-bold text-amber-400 tracking-wider">VAULT</h1>
-                <p className="text-xs text-green-300">FINANCIAL COMMAND CENTER</p>
+                <h1 className="text-2xl font-bold text-amber-400 tracking-wider">
+                  VAULT
+                </h1>
+                <p className="text-xs text-green-300">
+                  FINANCIAL COMMAND CENTER
+                </p>
               </div>
             </div>
-            <div className="text-right">
-              <div className="text-xs text-amber-300">SYSTEM STATUS</div>
-              <div className="text-sm text-green-400">● ONLINE</div>
+            <div className="text-right flex items-center gap-2">
+              <div>
+                <div className="text-xs text-amber-300">SYSTEM STATUS</div>
+                <div className="text-sm text-green-400">● ONLINE</div>
+              </div>
+              <button
+                onClick={() => navigate("/manage")}
+                className="px-2 py-1 text-xs font-bold border border-amber-400 text-amber-400 rounded hover:bg-slate-700/50"
+              >
+                ⚙️ Manage
+              </button>
             </div>
           </div>
         </div>
@@ -34,16 +47,16 @@ const Index = () => {
         <div className="container mx-auto px-4">
           <div className="flex gap-1">
             {[
-              { id: 'dashboard', label: 'DASHBOARD', icon: '📊' },
-              { id: 'simulator', label: 'SIMULATOR', icon: '🔮' }
+              { id: "dashboard", label: "DASHBOARD", icon: "📊" },
+              { id: "simulator", label: "SIMULATOR", icon: "🔮" },
             ].map((tab) => (
               <button
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
                 className={`px-6 py-3 text-sm font-bold border-b-2 transition-all duration-200 hover:bg-slate-700/50 ${
                   activeTab === tab.id
-                    ? 'border-amber-400 text-amber-400 bg-slate-800/50'
-                    : 'border-transparent text-slate-400'
+                    ? "border-amber-400 text-amber-400 bg-slate-800/50"
+                    : "border-transparent text-slate-400"
                 }`}
               >
                 {tab.icon} {tab.label}
@@ -55,8 +68,8 @@ const Index = () => {
 
       {/* Main Content */}
       <div className="container mx-auto px-4 py-6">
-        {activeTab === 'dashboard' && <Dashboard />}
-        {activeTab === 'simulator' && <BudgetSimulator baseData={baseData} />}
+        {activeTab === "dashboard" && <Dashboard />}
+        {activeTab === "simulator" && <BudgetSimulator baseData={baseData} />}
       </div>
 
       {/* Footer */}

--- a/src/pages/Manage.tsx
+++ b/src/pages/Manage.tsx
@@ -1,0 +1,48 @@
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { ArrowLeft } from "lucide-react";
+import BudgetManager from "../components/BudgetManager";
+import { useNavigate } from "react-router-dom";
+
+const Manage = () => {
+  const navigate = useNavigate();
+  const handleBack = () => navigate(-1);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-green-400 font-mono">
+      <div className="border-b-2 border-amber-400 bg-black/50 backdrop-blur-sm">
+        <div className="container mx-auto px-4 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <Button
+                onClick={handleBack}
+                variant="ghost"
+                size="sm"
+                className="text-amber-400 hover:text-amber-300 hover:bg-slate-700/50"
+              >
+                <ArrowLeft className="h-4 w-4 mr-2" />
+                Back
+              </Button>
+              <div className="flex items-center gap-4">
+                <div className="text-3xl">⚙️</div>
+                <div>
+                  <h1 className="text-2xl font-bold text-amber-400 tracking-wider">
+                    MANAGE BUDGET
+                  </h1>
+                  <p className="text-xs text-green-300">
+                    EDIT YOUR PLAN AND TRACK SPENDING
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="container mx-auto px-4 py-6">
+        <BudgetManager />
+      </div>
+    </div>
+  );
+};
+
+export default Manage;


### PR DESCRIPTION
## Summary
- remove editing sections from `CashflowCard`
- simplify `BalanceSheetCard` with progress bars for debt and savings
- add `BudgetManager` component with editing controls
- create `Manage` page and route for budget editing
- link to manage page from dashboard header

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68673a4cbadc832ba0480c982633d378