### PR TITLE
Adjust budget management workflow

### DIFF
--- a/src/components/BudgetManager.tsx
+++ b/src/components/BudgetManager.tsx
@@ -1,12 +1,11 @@
 import { Card } from "@/components/ui/card";
-import EditableFinancialData from "./EditableFinancialData";
 import SpentTracker from "./SpentTracker";
 import CategoryBreakdown from "./CategoryBreakdown";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useNavigate } from "react-router-dom";
 
 const BudgetManager = () => {
-  const { baseData, handleDataUpdate, handleSpentUpdate } = useDashboard();
+  const { baseData, handleSpentUpdate } = useDashboard();
   const navigate = useNavigate();
 
   const handleNeedsClick = () => navigate("/needs");
@@ -16,21 +15,6 @@ const BudgetManager = () => {
 
   return (
     <div className="space-y-6">
-      <Card className="bg-slate-800/50 border-slate-700 backdrop-blur-sm">
-        <div className="p-6">
-          <div className="flex items-center gap-3 mb-4">
-            <div className="w-10 h-10 bg-blue-400/20 rounded-full flex items-center justify-center">
-              <span className="text-lg">📊</span>
-            </div>
-            <h3 className="text-lg font-bold text-blue-400">BUDGET PLANNING</h3>
-          </div>
-          <EditableFinancialData
-            income={baseData.income}
-            categories={baseData.categories}
-            onUpdate={handleDataUpdate}
-          />
-        </div>
-      </Card>
       <Card className="bg-slate-800/50 border-slate-700 backdrop-blur-sm">
         <div className="p-6">
           <div className="flex items-center gap-3 mb-4">

--- a/src/components/DashboardData.tsx
+++ b/src/components/DashboardData.tsx
@@ -1,11 +1,11 @@
-import { useState } from 'react';
-import { DebtItem } from '@/types/debt';
-import { GoalItem } from '@/types/goals';
-import { Category } from '@/types/categories';
-import { BaseData } from '@/types/dashboard';
-import { usePersistedState } from '@/hooks/usePersistedState';
-import { toast } from '@/components/ui/sonner';
-import { defaultBaseData } from '@/data/defaultBaseData';
+import { useState, useEffect } from "react";
+import { DebtItem } from "@/types/debt";
+import { GoalItem } from "@/types/goals";
+import { Category } from "@/types/categories";
+import { BaseData } from "@/types/dashboard";
+import { usePersistedState } from "@/hooks/usePersistedState";
+import { toast } from "@/components/ui/sonner";
+import { defaultBaseData } from "@/data/defaultBaseData";
 
 export type { Category, GoalItem, BaseData };
 
@@ -15,21 +15,22 @@ export const useDashboardData = () => {
   // Migration function for handling data structure changes
   const migrateData = (oldData: any, oldVersion: number): BaseData => {
     console.log(`Migrating data from version ${oldVersion} to current version`);
-    
+
     // Add migration logic here as data structure evolves
     if (oldVersion < 2) {
       // Example: Add new fields that didn't exist in version 1
       if (oldData.goals) {
         oldData.goals = oldData.goals.map((goal: any) => ({
           ...goal,
-          plannedContribution: goal.plannedContribution || goal.monthlyContribution
+          plannedContribution:
+            goal.plannedContribution || goal.monthlyContribution,
         }));
       }
     }
-    
+
     return {
       ...defaultData,
-      ...oldData
+      ...oldData,
     };
   };
 
@@ -40,50 +41,89 @@ export const useDashboardData = () => {
     error,
     exportData,
     importData,
-    clearPersistedData
+    clearPersistedData,
   } = usePersistedState<BaseData>({
-    key: 'vault-dashboard-data',
+    key: "vault-dashboard-data",
     defaultValue: defaultData,
     version: 2,
-    migrate: migrateData
+    migrate: migrateData,
   });
 
-  const [debtStrategy, setDebtStrategy] = useState<'snowball' | 'avalanche'>('snowball');
+  const [debtStrategy, setDebtStrategy] = useState<"snowball" | "avalanche">(
+    "snowball",
+  );
 
   const handleDataUpdate = (newData: {
     income: number;
     categories: Category[];
   }) => {
-    setBaseData(prev => ({
-      ...prev,
-      income: newData.income,
-      categories: newData.categories
-    }));
-    toast.success('Budget plan updated successfully!');
+    setBaseData((prev) => {
+      const updatedCategories = prev.categories.map((cat) => {
+        if (cat.name === "NEEDS") {
+          const found = newData.categories.find((c) => c.name === "NEEDS");
+          return found ? { ...cat, budget: found.budget } : cat;
+        }
+        if (cat.name === "WANTS") {
+          const found = newData.categories.find((c) => c.name === "WANTS");
+          return found ? { ...cat, budget: found.budget } : cat;
+        }
+        return cat;
+      });
+      return {
+        ...prev,
+        income: newData.income,
+        categories: updatedCategories,
+      };
+    });
+    toast.success("Budget plan updated successfully!");
   };
 
-  const handleSpentUpdate = (newData: {
-    categories: Category[];
-  }) => {
-    setBaseData(prev => ({
+  const handleSpentUpdate = (newData: { categories: Category[] }) => {
+    setBaseData((prev) => ({
       ...prev,
-      categories: newData.categories
+      categories: newData.categories,
     }));
-    toast.success('Spending updated successfully!');
+    toast.success("Spending updated successfully!");
   };
 
   const handleDebtUpdate = (index: number, updatedDebt: DebtItem) => {
-    setBaseData(prev => ({
+    setBaseData((prev) => ({
       ...prev,
-      debts: prev.debts.map((debt, i) => i === index ? updatedDebt : debt)
+      debts: prev.debts.map((debt, i) => (i === index ? updatedDebt : debt)),
     }));
-    toast.success('Debt information updated!');
+    toast.success("Debt information updated!");
   };
 
-  const handleDebtStrategyChange = (strategy: 'snowball' | 'avalanche') => {
+  const handleDebtStrategyChange = (strategy: "snowball" | "avalanche") => {
     setDebtStrategy(strategy);
     toast.success(`Debt strategy changed to ${strategy}`);
   };
+
+  // Automatically calculate budgets for debt and goals categories
+  useEffect(() => {
+    setBaseData((prev) => {
+      const debtBudget = prev.debts.reduce(
+        (sum, debt) => sum + (debt.plannedPayment || debt.minPayment),
+        0,
+      );
+      const goalsBudget = prev.goals.reduce(
+        (sum, goal) =>
+          sum + (goal.plannedContribution || goal.monthlyContribution),
+        0,
+      );
+      const updatedCategories = prev.categories.map((cat) => {
+        if (cat.name === "DEBT") return { ...cat, budget: debtBudget };
+        if (cat.name === "GOALS") return { ...cat, budget: goalsBudget };
+        return cat;
+      });
+      if (
+        JSON.stringify(updatedCategories) === JSON.stringify(prev.categories)
+      ) {
+        return prev;
+      }
+      return { ...prev, categories: updatedCategories };
+    });
+  }, [baseData.debts, baseData.goals, setBaseData]);
 
   return {
     baseData,
@@ -97,6 +137,6 @@ export const useDashboardData = () => {
     handleDebtStrategyChange,
     exportData,
     importData,
-    clearPersistedData
+    clearPersistedData,
   };
 };

--- a/src/components/NeedsBreakdown.tsx
+++ b/src/components/NeedsBreakdown.tsx
@@ -1,3 +1,7 @@
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Plus, Minus } from "lucide-react";
 
 interface NeedsBreakdownProps {
   categories: Array<{
@@ -6,43 +10,115 @@ interface NeedsBreakdownProps {
     budget: number;
     color: string;
   }>;
+  onBudgetUpdate?: (newBudget: number) => void;
 }
 
-const NeedsBreakdown = ({ categories }: NeedsBreakdownProps) => {
-  const needsCategory = categories.find(cat => cat.name === 'NEEDS');
-  
+const NeedsBreakdown = ({
+  categories,
+  onBudgetUpdate,
+}: NeedsBreakdownProps) => {
+  const needsCategory = categories.find((cat) => cat.name === "NEEDS");
+
   if (!needsCategory) return null;
 
-  const percentage = needsCategory.budget > 0 ? (needsCategory.amount / needsCategory.budget) * 100 : 0;
+  const percentage =
+    needsCategory.budget > 0
+      ? (needsCategory.amount / needsCategory.budget) * 100
+      : 0;
+  const [editing, setEditing] = useState(false);
+  const [directValue, setDirectValue] = useState<string>("");
+  const [increment, setIncrement] = useState(100);
+
+  const handleDoubleClick = () => {
+    setEditing(true);
+    setDirectValue(needsCategory.budget.toString());
+  };
+
+  const handleIncrement = () => {
+    if (onBudgetUpdate) onBudgetUpdate(needsCategory.budget + increment);
+  };
+
+  const handleDecrement = () => {
+    if (onBudgetUpdate)
+      onBudgetUpdate(Math.max(0, needsCategory.budget - increment));
+  };
+
+  const handleDirectChange = (value: string) => {
+    setDirectValue(value);
+    const num = parseFloat(value);
+    if (!isNaN(num) && num >= 0 && onBudgetUpdate) {
+      onBudgetUpdate(num);
+    }
+  };
 
   return (
-    <div className="space-y-4">
-      <div className="text-center">
+    <div className="space-y-4" onClick={() => setEditing(false)}>
+      <div
+        className="text-center"
+        onDoubleClick={handleDoubleClick}
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="text-2xl font-bold text-amber-400">
-          ${needsCategory.amount.toLocaleString()} / ${needsCategory.budget.toLocaleString()}
+          ${needsCategory.amount.toLocaleString()} / $
+          {needsCategory.budget.toLocaleString()}
         </div>
         <div className="text-slate-400">
           {percentage.toFixed(1)}% of budget spent
         </div>
+        {editing && onBudgetUpdate && (
+          <div className="mt-3 space-y-2">
+            <Input
+              type="number"
+              value={directValue}
+              onChange={(e) => handleDirectChange(e.target.value)}
+              className="text-sm bg-slate-700 border-slate-600 text-white"
+              placeholder="Enter amount"
+            />
+            <div className="flex items-center justify-center gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleDecrement}
+                className="bg-red-600 hover:bg-red-700 text-white border-red-600"
+              >
+                <Minus className="w-3 h-3" />
+              </Button>
+              <span className="text-white text-xs">±{increment}</span>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleIncrement}
+                className="bg-green-600 hover:bg-green-700 text-white border-green-600"
+              >
+                <Plus className="w-3 h-3" />
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
-      
+
       <div className="bg-slate-700 h-4 rounded overflow-hidden">
-        <div 
+        <div
           className={`h-full transition-all duration-500 ${
-            percentage >= 100 ? 'bg-red-500' : 
-            percentage >= 80 ? 'bg-orange-500' : 
-            'bg-green-500'
+            percentage >= 100
+              ? "bg-red-500"
+              : percentage >= 80
+                ? "bg-orange-500"
+                : "bg-green-500"
           }`}
           style={{ width: `${Math.min(percentage, 100)}%` }}
         />
       </div>
 
       <div className="space-y-3">
-        <h3 className="text-lg font-semibold text-slate-300">Essential Expenses</h3>
+        <h3 className="text-lg font-semibold text-slate-300">
+          Essential Expenses
+        </h3>
         <div className="text-slate-400 text-sm">
-          This category includes rent/mortgage, utilities, groceries, transportation, insurance, and other essential living expenses.
+          This category includes rent/mortgage, utilities, groceries,
+          transportation, insurance, and other essential living expenses.
         </div>
-        
+
         <div className="grid grid-cols-2 gap-4 text-sm">
           <div className="bg-slate-700/50 p-3 rounded">
             <div className="text-slate-400">Remaining Budget</div>
@@ -52,14 +128,20 @@ const NeedsBreakdown = ({ categories }: NeedsBreakdownProps) => {
           </div>
           <div className="bg-slate-700/50 p-3 rounded">
             <div className="text-slate-400">Status</div>
-            <div className={`text-lg font-bold ${
-              percentage >= 100 ? 'text-red-400' : 
-              percentage >= 80 ? 'text-orange-400' : 
-              'text-green-400'
-            }`}>
-              {percentage >= 100 ? 'Over Budget' : 
-               percentage >= 80 ? 'Near Limit' : 
-               'On Track'}
+            <div
+              className={`text-lg font-bold ${
+                percentage >= 100
+                  ? "text-red-400"
+                  : percentage >= 80
+                    ? "text-orange-400"
+                    : "text-green-400"
+              }`}
+            >
+              {percentage >= 100
+                ? "Over Budget"
+                : percentage >= 80
+                  ? "Near Limit"
+                  : "On Track"}
             </div>
           </div>
         </div>

--- a/src/components/WantsBreakdown.tsx
+++ b/src/components/WantsBreakdown.tsx
@@ -1,3 +1,7 @@
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Plus, Minus } from "lucide-react";
 
 interface WantsBreakdownProps {
   categories: Array<{
@@ -7,43 +11,116 @@ interface WantsBreakdownProps {
     color: string;
   }>;
   income?: number;
+  onBudgetUpdate?: (newBudget: number) => void;
 }
 
-const WantsBreakdown = ({ categories, income = 0 }: WantsBreakdownProps) => {
-  const wantsCategory = categories.find(cat => cat.name === 'WANTS');
-  
+const WantsBreakdown = ({
+  categories,
+  income = 0,
+  onBudgetUpdate,
+}: WantsBreakdownProps) => {
+  const wantsCategory = categories.find((cat) => cat.name === "WANTS");
+
   if (!wantsCategory) return null;
 
-  const percentage = wantsCategory.budget > 0 ? (wantsCategory.amount / wantsCategory.budget) * 100 : 0;
+  const percentage =
+    wantsCategory.budget > 0
+      ? (wantsCategory.amount / wantsCategory.budget) * 100
+      : 0;
+  const [editing, setEditing] = useState(false);
+  const [directValue, setDirectValue] = useState<string>("");
+  const [increment, setIncrement] = useState(100);
+
+  const handleDoubleClick = () => {
+    setEditing(true);
+    setDirectValue(wantsCategory.budget.toString());
+  };
+
+  const handleIncrement = () => {
+    if (onBudgetUpdate) onBudgetUpdate(wantsCategory.budget + increment);
+  };
+
+  const handleDecrement = () => {
+    if (onBudgetUpdate)
+      onBudgetUpdate(Math.max(0, wantsCategory.budget - increment));
+  };
+
+  const handleDirectChange = (value: string) => {
+    setDirectValue(value);
+    const num = parseFloat(value);
+    if (!isNaN(num) && num >= 0 && onBudgetUpdate) {
+      onBudgetUpdate(num);
+    }
+  };
 
   return (
-    <div className="space-y-4">
-      <div className="text-center">
+    <div className="space-y-4" onClick={() => setEditing(false)}>
+      <div
+        className="text-center"
+        onDoubleClick={handleDoubleClick}
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="text-2xl font-bold text-amber-400">
-          ${wantsCategory.amount.toLocaleString()} / ${wantsCategory.budget.toLocaleString()}
+          ${wantsCategory.amount.toLocaleString()} / $
+          {wantsCategory.budget.toLocaleString()}
         </div>
         <div className="text-slate-400">
           {percentage.toFixed(1)}% of budget spent
         </div>
+        {editing && onBudgetUpdate && (
+          <div className="mt-3 space-y-2">
+            <Input
+              type="number"
+              value={directValue}
+              onChange={(e) => handleDirectChange(e.target.value)}
+              className="text-sm bg-slate-700 border-slate-600 text-white"
+              placeholder="Enter amount"
+            />
+            <div className="flex items-center justify-center gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleDecrement}
+                className="bg-red-600 hover:bg-red-700 text-white border-red-600"
+              >
+                <Minus className="w-3 h-3" />
+              </Button>
+              <span className="text-white text-xs">±{increment}</span>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleIncrement}
+                className="bg-green-600 hover:bg-green-700 text-white border-green-600"
+              >
+                <Plus className="w-3 h-3" />
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
-      
+
       <div className="bg-slate-700 h-4 rounded overflow-hidden">
-        <div 
+        <div
           className={`h-full transition-all duration-500 ${
-            percentage >= 100 ? 'bg-red-500' : 
-            percentage >= 80 ? 'bg-orange-500' : 
-            'bg-green-500'
+            percentage >= 100
+              ? "bg-red-500"
+              : percentage >= 80
+                ? "bg-orange-500"
+                : "bg-green-500"
           }`}
           style={{ width: `${Math.min(percentage, 100)}%` }}
         />
       </div>
 
       <div className="space-y-3">
-        <h3 className="text-lg font-semibold text-slate-300">Discretionary Spending</h3>
+        <h3 className="text-lg font-semibold text-slate-300">
+          Discretionary Spending
+        </h3>
         <div className="text-slate-400 text-sm">
-          This category includes entertainment, dining out, hobbies, subscriptions, and other non-essential purchases.
+          This category includes entertainment, dining out, hobbies,
+          subscriptions, and other non-essential purchases.
         </div>
-        
+
         <div className="grid grid-cols-2 gap-4 text-sm">
           <div className="bg-slate-700/50 p-3 rounded">
             <div className="text-slate-400">Remaining Budget</div>
@@ -53,14 +130,20 @@ const WantsBreakdown = ({ categories, income = 0 }: WantsBreakdownProps) => {
           </div>
           <div className="bg-slate-700/50 p-3 rounded">
             <div className="text-slate-400">Status</div>
-            <div className={`text-lg font-bold ${
-              percentage >= 100 ? 'text-red-400' : 
-              percentage >= 80 ? 'text-orange-400' : 
-              'text-green-400'
-            }`}>
-              {percentage >= 100 ? 'Over Budget' : 
-               percentage >= 80 ? 'Near Limit' : 
-               'On Track'}
+            <div
+              className={`text-lg font-bold ${
+                percentage >= 100
+                  ? "text-red-400"
+                  : percentage >= 80
+                    ? "text-orange-400"
+                    : "text-green-400"
+              }`}
+            >
+              {percentage >= 100
+                ? "Over Budget"
+                : percentage >= 80
+                  ? "Near Limit"
+                  : "On Track"}
             </div>
           </div>
         </div>

--- a/src/data/defaultBaseData.ts
+++ b/src/data/defaultBaseData.ts
@@ -1,96 +1,96 @@
-import { BaseData } from '@/types/dashboard';
+import { BaseData } from "@/types/dashboard";
 
 export const defaultBaseData: BaseData = {
   income: 5000,
   categories: [
     {
-      name: 'NEEDS' as const,
+      name: "NEEDS" as const,
       amount: 0,
       budget: 2500,
-      color: 'bg-red-500'
+      color: "bg-red-500",
     },
     {
-      name: 'WANTS' as const,
+      name: "WANTS" as const,
       amount: 0,
       budget: 1000,
-      color: 'bg-orange-500'
+      color: "bg-orange-500",
     },
     {
-      name: 'DEBT' as const,
+      name: "DEBT" as const,
       amount: 0,
-      budget: 400,
-      color: 'bg-yellow-500'
+      budget: 800,
+      color: "bg-yellow-500",
     },
     {
-      name: 'GOALS' as const,
+      name: "GOALS" as const,
       amount: 0,
-      budget: 1800,
-      color: 'bg-green-500'
-    }
+      budget: 2650,
+      color: "bg-green-500",
+    },
   ],
   debts: [
     {
-      name: 'Credit Card - Chase',
+      name: "Credit Card - Chase",
       balance: 3500,
       minPayment: 105,
       plannedPayment: 200,
       totalPaid: 150,
       interestRate: 24.99,
-      type: 'credit_card' as const
+      type: "credit_card" as const,
     },
     {
-      name: 'Student Loan',
+      name: "Student Loan",
       balance: 15000,
       minPayment: 180,
       plannedPayment: 250,
       totalPaid: 180,
       interestRate: 6.5,
-      type: 'loan' as const
+      type: "loan" as const,
     },
     {
-      name: 'Car Loan',
+      name: "Car Loan",
       balance: 12000,
       minPayment: 285,
       plannedPayment: 350,
       totalPaid: 285,
       interestRate: 4.2,
-      type: 'loan' as const
-    }
+      type: "loan" as const,
+    },
   ],
   goals: [
     {
-      name: 'Emergency Fund',
+      name: "Emergency Fund",
       target: 15000,
       current: 8500,
       monthlyContribution: 500,
       plannedContribution: 750,
-      type: 'emergency_fund' as const,
-      deadline: 'Dec 2025'
+      type: "emergency_fund" as const,
+      deadline: "Dec 2025",
     },
     {
-      name: 'Retirement 401k',
+      name: "Retirement 401k",
       target: 100000,
       current: 35000,
       monthlyContribution: 800,
       plannedContribution: 1000,
-      type: 'retirement' as const
+      type: "retirement" as const,
     },
     {
-      name: 'Vacation Fund',
+      name: "Vacation Fund",
       target: 5000,
       current: 1200,
       monthlyContribution: 200,
       plannedContribution: 300,
-      type: 'vacation' as const,
-      deadline: 'Jun 2025'
+      type: "vacation" as const,
+      deadline: "Jun 2025",
     },
     {
-      name: 'Stock Portfolio',
+      name: "Stock Portfolio",
       target: 25000,
       current: 12500,
       monthlyContribution: 400,
       plannedContribution: 600,
-      type: 'investment' as const
-    }
-  ]
+      type: "investment" as const,
+    },
+  ],
 };

--- a/src/pages/NeedsDetails.tsx
+++ b/src/pages/NeedsDetails.tsx
@@ -1,13 +1,12 @@
-
-import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { ArrowLeft } from 'lucide-react';
-import NeedsBreakdown from '../components/NeedsBreakdown';
-import { useDashboard } from '../contexts/DashboardContext';
-import { useNavigate } from 'react-router-dom';
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import NeedsBreakdown from "../components/NeedsBreakdown";
+import { useDashboard } from "../contexts/DashboardContext";
+import { useNavigate } from "react-router-dom";
 
 const NeedsDetails = () => {
-  const { baseData } = useDashboard();
+  const { baseData, handleDataUpdate } = useDashboard();
   const navigate = useNavigate();
 
   const handleBack = () => {
@@ -21,9 +20,9 @@ const NeedsDetails = () => {
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <Button 
+              <Button
                 onClick={handleBack}
-                variant="ghost" 
+                variant="ghost"
                 size="sm"
                 className="text-amber-400 hover:text-amber-300 hover:bg-slate-700/50"
               >
@@ -33,8 +32,12 @@ const NeedsDetails = () => {
               <div className="flex items-center gap-4">
                 <div className="text-3xl">🏠</div>
                 <div>
-                  <h1 className="text-2xl font-bold text-amber-400 tracking-wider">NEEDS TRACKER</h1>
-                  <p className="text-xs text-green-300">ESSENTIAL EXPENSES BREAKDOWN</p>
+                  <h1 className="text-2xl font-bold text-amber-400 tracking-wider">
+                    NEEDS TRACKER
+                  </h1>
+                  <p className="text-xs text-green-300">
+                    ESSENTIAL EXPENSES BREAKDOWN
+                  </p>
                 </div>
               </div>
             </div>
@@ -46,7 +49,18 @@ const NeedsDetails = () => {
       <div className="container mx-auto px-4 py-6">
         <Card className="bg-slate-800/50 border-slate-700 backdrop-blur-sm">
           <div className="p-6">
-            <NeedsBreakdown categories={baseData.categories} />
+            <NeedsBreakdown
+              categories={baseData.categories}
+              onBudgetUpdate={(budget) => {
+                const updated = baseData.categories.map((c) =>
+                  c.name === "NEEDS" ? { ...c, budget } : c,
+                );
+                handleDataUpdate({
+                  income: baseData.income,
+                  categories: updated,
+                });
+              }}
+            />
           </div>
         </Card>
       </div>

--- a/src/pages/WantsDetails.tsx
+++ b/src/pages/WantsDetails.tsx
@@ -1,13 +1,12 @@
-
-import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { ArrowLeft } from 'lucide-react';
-import WantsBreakdown from '../components/WantsBreakdown';
-import { useDashboard } from '../contexts/DashboardContext';
-import { useNavigate } from 'react-router-dom';
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import WantsBreakdown from "../components/WantsBreakdown";
+import { useDashboard } from "../contexts/DashboardContext";
+import { useNavigate } from "react-router-dom";
 
 const WantsDetails = () => {
-  const { baseData } = useDashboard();
+  const { baseData, handleDataUpdate } = useDashboard();
   const navigate = useNavigate();
 
   const handleBack = () => {
@@ -21,9 +20,9 @@ const WantsDetails = () => {
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <Button 
+              <Button
                 onClick={handleBack}
-                variant="ghost" 
+                variant="ghost"
                 size="sm"
                 className="text-amber-400 hover:text-amber-300 hover:bg-slate-700/50"
               >
@@ -33,8 +32,12 @@ const WantsDetails = () => {
               <div className="flex items-center gap-4">
                 <div className="text-3xl">🎮</div>
                 <div>
-                  <h1 className="text-2xl font-bold text-amber-400 tracking-wider">WANTS TRACKER</h1>
-                  <p className="text-xs text-green-300">DISCRETIONARY SPENDING BREAKDOWN</p>
+                  <h1 className="text-2xl font-bold text-amber-400 tracking-wider">
+                    WANTS TRACKER
+                  </h1>
+                  <p className="text-xs text-green-300">
+                    DISCRETIONARY SPENDING BREAKDOWN
+                  </p>
                 </div>
               </div>
             </div>
@@ -46,7 +49,19 @@ const WantsDetails = () => {
       <div className="container mx-auto px-4 py-6">
         <Card className="bg-slate-800/50 border-slate-700 backdrop-blur-sm">
           <div className="p-6">
-            <WantsBreakdown categories={baseData.categories} income={baseData.income} />
+            <WantsBreakdown
+              categories={baseData.categories}
+              income={baseData.income}
+              onBudgetUpdate={(budget) => {
+                const updated = baseData.categories.map((c) =>
+                  c.name === "WANTS" ? { ...c, budget } : c,
+                );
+                handleDataUpdate({
+                  income: baseData.income,
+                  categories: updated,
+                });
+              }}
+            />
           </div>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- drop EditableFinancialData from the Manage page
- allow editing Needs/Wants budgets inside their detail pages
- compute Debt and Goal budgets automatically
- update default budgets accordingly

## Testing
- `npx prettier -w src/components/BudgetManager.tsx src/components/DashboardData.tsx src/components/NeedsBreakdown.tsx src/components/WantsBreakdown.tsx src/data/defaultBaseData.ts src/pages/NeedsDetails.tsx src/pages/WantsDetails.tsx`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867415bd478832b8af494596392ae67