### PR TITLE
Add editable total debt budget

### DIFF
--- a/src/components/DashboardData.tsx
+++ b/src/components/DashboardData.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { DebtItem } from "@/types/debt";
+import { calculateDebtStrategy } from "@/utils/debtStrategies";
 import { GoalItem } from "@/types/goals";
 import { Category } from "@/types/categories";
 import { BaseData } from "@/types/dashboard";
@@ -94,6 +95,22 @@ export const useDashboardData = () => {
     toast.success("Debt information updated!");
   };
 
+  const handleDebtBudgetUpdate = (newBudget: number) => {
+    setBaseData(prev => {
+      const strategicDebts = calculateDebtStrategy(prev.debts, debtStrategy, newBudget);
+      const updatedDebts = prev.debts.map(debt => {
+        const match = strategicDebts.find(d =>
+          d.name === debt.name &&
+          d.balance === debt.balance &&
+          d.interestRate === debt.interestRate
+        );
+        return match ? { ...debt, plannedPayment: match.recommendedPayment } : debt;
+      });
+      return { ...prev, debts: updatedDebts };
+    });
+    toast.success("Debt budget updated!");
+  };
+
   const handleDebtStrategyChange = (strategy: "snowball" | "avalanche") => {
     setDebtStrategy(strategy);
     toast.success(`Debt strategy changed to ${strategy}`);
@@ -134,6 +151,7 @@ export const useDashboardData = () => {
     handleDataUpdate,
     handleSpentUpdate,
     handleDebtUpdate,
+    handleDebtBudgetUpdate,
     handleDebtStrategyChange,
     exportData,
     importData,

--- a/src/components/DebtBreakdown.tsx
+++ b/src/components/DebtBreakdown.tsx
@@ -119,7 +119,7 @@ const DebtBreakdown = ({
       </div>
 
       {/* Summary */}
-      <DebtSummaryCards debts={debts} />
+      <DebtSummaryCards debts={debts} debtBudget={debtBudget} onBudgetUpdate={onBudgetUpdate} />
 
       {/* Monthly Debt Payment Progress - Against Budget */}
       <MonthlyDebtProgress 

--- a/src/components/DebtTrackerCard.tsx
+++ b/src/components/DebtTrackerCard.tsx
@@ -10,6 +10,7 @@ interface DebtTrackerCardProps {
   debtBudget?: number;
   debtSpent?: number;
   strategy?: DebtStrategy;
+  onBudgetUpdate?: (newBudget: number) => void;
   onStrategyChange?: (strategy: DebtStrategy) => void;
 }
 
@@ -18,7 +19,8 @@ const DebtTrackerCard = ({
   debtBudget = 0, 
   debtSpent = 0,
   strategy = 'snowball',
-  onStrategyChange 
+  onBudgetUpdate,
+  onStrategyChange
 }: DebtTrackerCardProps) => {
   return (
     <Card className="bg-slate-800/50 border-slate-700 backdrop-blur-sm">
@@ -40,8 +42,9 @@ const DebtTrackerCard = ({
             </Select>
           )}
         </div>
-        <DebtBreakdown 
-          debts={debts} 
+        <DebtBreakdown
+          debts={debts}
+          onBudgetUpdate={onBudgetUpdate}
           debtBudget={debtBudget}
           debtSpent={debtSpent}
           strategy={strategy}

--- a/src/components/debt/DebtSummaryCards.tsx
+++ b/src/components/debt/DebtSummaryCards.tsx
@@ -1,16 +1,48 @@
 
+import { useState } from 'react';
 import { DebtItem } from '@/types/debt';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Plus, Minus } from 'lucide-react';
 
 interface DebtSummaryCardsProps {
   debts: DebtItem[];
+  debtBudget?: number;
+  onBudgetUpdate?: (newBudget: number) => void;
 }
 
-const DebtSummaryCards = ({ debts }: DebtSummaryCardsProps) => {
+const DebtSummaryCards = ({ debts, debtBudget, onBudgetUpdate }: DebtSummaryCardsProps) => {
   const totalDebt = debts.reduce((sum, debt) => sum + debt.balance, 0);
   const totalMinPayments = debts.reduce((sum, debt) => sum + debt.minPayment, 0);
+  const budgetAmount = debtBudget ?? debts.reduce((sum, debt) => sum + (debt.plannedPayment || debt.minPayment), 0);
+
+  const [editing, setEditing] = useState(false);
+  const [directValue, setDirectValue] = useState('');
+  const [increment] = useState(100);
+
+  const handleDoubleClick = () => {
+    setEditing(true);
+    setDirectValue(budgetAmount.toString());
+  };
+
+  const handleIncrement = () => {
+    if (onBudgetUpdate) onBudgetUpdate(budgetAmount + increment);
+  };
+
+  const handleDecrement = () => {
+    if (onBudgetUpdate) onBudgetUpdate(Math.max(0, budgetAmount - increment));
+  };
+
+  const handleDirectChange = (value: string) => {
+    setDirectValue(value);
+    const num = parseFloat(value);
+    if (!isNaN(num) && num >= 0 && onBudgetUpdate) {
+      onBudgetUpdate(num);
+    }
+  };
 
   return (
-    <div className="grid grid-cols-2 gap-4">
+    <div className="grid grid-cols-3 gap-4" onClick={() => setEditing(false)}>
       <div className="bg-black/30 p-3 rounded border border-slate-600">
         <div className="text-xs text-slate-400 mb-1">TOTAL DEBT</div>
         <div className="text-lg font-bold text-red-400">${totalDebt.toLocaleString()}</div>
@@ -18,6 +50,44 @@ const DebtSummaryCards = ({ debts }: DebtSummaryCardsProps) => {
       <div className="bg-black/30 p-3 rounded border border-slate-600">
         <div className="text-xs text-slate-400 mb-1">MIN PAYMENTS</div>
         <div className="text-lg font-bold text-orange-400">${totalMinPayments.toLocaleString()}</div>
+      </div>
+      <div
+        className="bg-black/30 p-3 rounded border border-slate-600"
+        onDoubleClick={handleDoubleClick}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="text-xs text-slate-400 mb-1">TOTAL BUDGETED</div>
+        <div className="text-lg font-bold text-blue-400">${budgetAmount.toLocaleString()}</div>
+        {editing && onBudgetUpdate && (
+          <div className="mt-3 space-y-2">
+            <Input
+              type="number"
+              value={directValue}
+              onChange={(e) => handleDirectChange(e.target.value)}
+              className="text-sm bg-slate-700 border-slate-600 text-white"
+              placeholder="Enter amount"
+            />
+            <div className="flex items-center justify-center gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleDecrement}
+                className="bg-red-600 hover:bg-red-700 text-white border-red-600"
+              >
+                <Minus className="w-3 h-3" />
+              </Button>
+              <span className="text-white text-xs">±{increment}</span>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleIncrement}
+                className="bg-green-600 hover:bg-green-700 text-white border-green-600"
+              >
+                <Plus className="w-3 h-3" />
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/contexts/DashboardContext.tsx
+++ b/src/contexts/DashboardContext.tsx
@@ -20,6 +20,7 @@ interface DashboardContextType {
     categories: Category[];
   }) => void;
   handleDebtUpdate: (index: number, updatedDebt: DebtItem) => void;
+  handleDebtBudgetUpdate: (newBudget: number) => void;
   handleDebtStrategyChange: (strategy: 'snowball' | 'avalanche') => void;
   handleGoalUpdate: (index: number, updatedGoal: GoalItem) => void;
   handleDeleteGoal: (index: number) => void;
@@ -76,6 +77,10 @@ export const DashboardProvider = ({ children }: DashboardProviderProps) => {
     }));
   };
 
+  const handleDebtBudgetUpdate = (newBudget: number) => {
+    dashboardData.handleDebtBudgetUpdate(newBudget);
+  };
+
   const contextValue: DashboardContextType = {
     baseData: dashboardData.baseData,
     setBaseData: dashboardData.setBaseData,
@@ -85,6 +90,7 @@ export const DashboardProvider = ({ children }: DashboardProviderProps) => {
     handleDataUpdate: dashboardData.handleDataUpdate,
     handleSpentUpdate: dashboardData.handleSpentUpdate,
     handleDebtUpdate: dashboardData.handleDebtUpdate,
+    handleDebtBudgetUpdate,
     handleDebtStrategyChange: dashboardData.handleDebtStrategyChange,
     handleGoalUpdate,
     handleDeleteGoal,

--- a/src/pages/DebtDetails.tsx
+++ b/src/pages/DebtDetails.tsx
@@ -13,7 +13,8 @@ const DebtDetails = () => {
     handleDebtUpdate,
     handleDebtStrategyChange,
     handleDeleteDebt,
-    handleAddDebt
+    handleAddDebt,
+    handleDebtBudgetUpdate
   } = useDashboard();
 
   const navigate = useNavigate();
@@ -63,11 +64,12 @@ const DebtDetails = () => {
       <div className="container mx-auto px-4 py-6">
         <Card className="bg-slate-800/50 border-slate-700 backdrop-blur-sm">
           <div className="p-6">
-            <DebtBreakdown 
-              debts={baseData.debts} 
+            <DebtBreakdown
+              debts={baseData.debts}
               onUpdateDebt={handleDebtUpdate}
               onDeleteDebt={handleDeleteDebt}
               onAddDebt={handleAddDebt}
+              onBudgetUpdate={handleDebtBudgetUpdate}
               debtBudget={debtBudget}
               debtSpent={debtSpent}
               strategy={debtStrategy}


### PR DESCRIPTION
## Summary
- add function to update overall debt budget via `useDashboardData`
- expose the new handler through the dashboard context
- display and edit total budgeted amount in `DebtSummaryCards`
- pass budget update handler down from `DebtDetails`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_6869cd3ce478832b80f755d4f527be34